### PR TITLE
Support Github Enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## v0.6.0 (2026-01-28)
+
+  - Support for GitHub Enterprise
+  - Accept GitHub Enterprise flag via `--enterprise` (default: false)
+  - Require Enterprise URL from `ENTERPRISE_URL` environment variable when GitHub Enterprise is enabled
+
 ## v0.5.1 (2021-04-05)
 
  - Fix the whitespaces issues when reading yaml list

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can download the binary built for your architecture from [the latest release
 The following is an example of installation on macOS:
 
 ```console
-$ curl https://github.com/amirashad/ghctl/releases/download/v0.5.0/ghctl_darwin_amd64 -L -o /usr/local/bin/ghctl
+$ curl https://github.com/amirashad/ghctl/releases/download/v0.6.0/ghctl_darwin_amd64 -L -o /usr/local/bin/ghctl
 $ chmod +x /usr/local/bin/ghctl
 ```
 
@@ -47,7 +47,7 @@ $ curl -L "$(curl -Ls https://api.github.com/repos/amirashad/ghctl/releases/late
 
 For Windows OS, you can use following PowerShell command to download binary for AMD64 architecture.
 ```
-Invoke-WebRequest https://github.com/amirashad/ghctl/releases/download/v0.5.0/ghctl_windows_amd64.exe -O ghctl.exe
+Invoke-WebRequest https://github.com/amirashad/ghctl/releases/download/v0.6.0/ghctl_windows_amd64.exe -O ghctl.exe
 ```
 
 </p></details>
@@ -92,7 +92,9 @@ Usage: ghctl [OPTIONS] [COMMANDS] [FILE]
 OPTIONS:
       --token                                   GitHub token
       --org                                     GitHub organisation
+      --enterpriseurl                           Github Enterprise URL
       --version                                 Display version and exit
+      --enterprise,                             Is GitHub Enterprise (default: false)
   -o, --outputformat=[normal|json|yaml]         Output format (default: normal)
   -v, --verbose,                                Show debug output (default: false)
   -h, --help,                                   Display this help and exit
@@ -193,6 +195,12 @@ ghctl returns the following exit statuses on exit:
 ## FAQ
 ### Does ghctl create projects?
 - No. ghctl not yet supports project creation.
+
+### How to use `ghctl` with GitHub Enterprise?
+- Set the environment variable ENTERPRISE_URL or pass it directly using the --enterpriseurl flag, along with the --enterprise flag to enable Enterprise mode.
+```console
+$ ghctl create repo --name my-repo --enterprise
+```
 
 ## Debugging
 

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/go-github/v33/github"
 	"golang.org/x/oauth2"
@@ -10,6 +11,19 @@ import (
 func createGithubClient(ctx context.Context) *github.Client {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: args.Token})
 	tc := oauth2.NewClient(ctx, ts)
-	client := github.NewClient(tc)
+
+	var client *github.Client
+	var err error
+
+	if args.Enterprise {
+		baseUrl := fmt.Sprintf("%s/api/v3/", args.EnterpriseUrl)
+		uploadUrl := fmt.Sprintf("%s/api/uploads/", args.EnterpriseUrl)
+
+		client, err = github.NewEnterpriseClient(baseUrl, uploadUrl, tc)
+		CheckIfError(err)
+	} else {
+		client = github.NewClient(tc)
+	}
+
 	return client
 }

--- a/examples/.circleci/config.yml
+++ b/examples/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   ghctl:
     docker:
-      - image: amirashad/ghctl:0.5.0
+      - image: amirashad/ghctl:0.6.0
 
 commands:
   validate:

--- a/flag.go
+++ b/flag.go
@@ -1,10 +1,14 @@
 package main
 
+import "fmt"
+
 type Args struct {
-	Token        string `arg:"env:GITHUB_TOKEN,required"`
-	Org          string `arg:"env:GITHUB_ORG,required"`
-	OutputFormat string `arg:"-o" help:"output format: normal, json" default:"normal"`
-	Verbose      bool   `arg:"-v" default:"false"`
+	Token         string `arg:"env:GITHUB_TOKEN,required"`
+	Org           string `arg:"env:GITHUB_ORG,required"`
+	EnterpriseUrl string `arg:"env:ENTERPRISE_URL"`
+	Enterprise    bool   `arg:"--enterprise" help:"Is GitHub Enterprise (default: false)" default:"false"`
+	OutputFormat  string `arg:"-o" help:"output format: normal, json" default:"normal"`
+	Verbose       bool   `arg:"-v" default:"false"`
 
 	Get    *Get    `arg:"subcommand:get"`
 	Create *Create `arg:"subcommand:create"`
@@ -14,7 +18,13 @@ type Args struct {
 }
 
 func (Args) Version() string {
-	return "0.5.1"
+	return "0.6.0"
+}
+
+func (a *Args) Validate() {
+	if a.Enterprise && a.EnterpriseUrl == "" {
+		CheckIfError(fmt.Errorf("ENTERPRISE_URL is required when --enterprise is set"))
+	}
 }
 
 type Get struct {

--- a/git.go
+++ b/git.go
@@ -25,7 +25,7 @@ func createBranch(org string, repo string, branch string, format string) {
 	}
 
 	// Clone the given repository to the memory
-	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", org, repo)
+	repoURL := GenerateRepoURL(org, repo)
 	Info("git clone %s", repoURL)
 	r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 		URL:  repoURL,
@@ -77,7 +77,7 @@ func addFile(org, repo, branch, fileFrom, fileTo, commitMessage, gitEmail, forma
 	defer os.RemoveAll(dir)
 
 	// Clone the given repository to the memory
-	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", org, repo)
+	repoURL := GenerateRepoURL(org, repo)
 	Info("git clone %s", repoURL)
 	r, err := git.PlainClone(dir, false, &git.CloneOptions{
 		URL:           repoURL,
@@ -156,6 +156,14 @@ func copyFile(from, to string) {
 		fmt.Println(err)
 		return
 	}
+}
+
+func GenerateRepoURL(org, repo string) string {
+	if args.Enterprise {
+		return fmt.Sprintf("%s/%s/%s.git", args.EnterpriseUrl, org, repo)
+	}
+
+	return fmt.Sprintf("https://github.com/%s/%s.git", org, repo)
 }
 
 // CheckIfError should be used to naively panics if an error is not nil.

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func Test_GenerateRepoURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        Args
+		org, repo   string
+		expectedURL string
+	}{
+		{
+			name: "GitHub URL",
+			args: Args{
+				Enterprise: false,
+			},
+			org:         "exampleOrg",
+			repo:        "exampleRepo",
+			expectedURL: "https://github.com/exampleOrg/exampleRepo.git",
+		},
+		{
+			name: "Enterprise URL",
+			args: Args{
+				Enterprise:    true,
+				EnterpriseUrl: "https://enterprise.example.com",
+			},
+			org:         "exampleOrg",
+			repo:        "exampleRepo",
+			expectedURL: "https://enterprise.example.com/exampleOrg/exampleRepo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args = tt.args
+			got := GenerateRepoURL(tt.org, tt.repo)
+			if got != tt.expectedURL {
+				t.Errorf("generateRepoURL() = %v, want %v", got, tt.expectedURL)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ var args Args
 
 func main() {
 	arg.MustParse(&args)
+	args.Validate()
 
 	if args.Get != nil && args.Get.Repos != nil {
 		if args.Get.Repos.RepoName != nil {


### PR DESCRIPTION
ghctl now supports GitHub Enterprise.

You can enable GitHub Enterprise mode using the `-e` command-line flag.
When enabled, the `ENTERPRISE_URL` environment variable must be set. Otherwise, the tool will exit with an error.